### PR TITLE
Update supported OpenShift version

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -20,6 +20,6 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
 
-LABEL com.redhat.openshift.versions="v4.6"
+LABEL com.redhat.openshift.versions="v4.8"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.delivery.backport=true


### PR DESCRIPTION
The Operator Bundle certification fails with any version < 4.8 with a message that says they've reached its end of life