### PR TITLE
Increase operator memory limit

### DIFF
--- a/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
@@ -380,7 +380,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 256Mi
+                    memory: 1Gi
                   requests:
                     cpu: 250m
                     memory: 128Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -89,7 +89,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 1Gi
           requests:
             cpu: 250m
             memory: 128Mi


### PR DESCRIPTION
### Proposed changes
Due to the Helm Operator's caching behaviour, increase the memory limit of the operator to reduce the occurrence of `OOMkilled` events

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork