### PR TITLE
Revert "Update docs for v1.3.1 (#72)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-### 1.3.1
+### 1.3.0
 
-An automatically generated list of changes can be found on Github at: [1.3.1 Release](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.3.1)
+An automatically generated list of changes can be found on Github at: [1.3.0 Release](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.3.0)
 
 ### 1.2.1
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.3.1
+VERSION ?= 1.3.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following table shows the relation between the versions of the two projects:
 
 | NGINX Ingress Controller | NGINX Ingress Operator |
 | --- | --- |
-| 3.0.x | 1.3.1 |
+| 3.0.x | 1.3.0 |
 | 2.4.x | 1.2.1 |
 | 2.3.x | 1.1.0 |
 | 2.2.x | 1.0.0 |
@@ -34,10 +34,10 @@ Note: The NGINX Ingress Operator works only for NGINX Ingress Controller version
 
 1. Install the NGINX Ingress Operator. See [docs](./docs/installation.md).
    <br> NOTE: To use TransportServers as part of your NGINX Ingress Controller configuration, a GlobalConfiguration resource must be created *before* starting the Operator - [see the notes](./examples/deployment-oss-min/README.md#TransportServers)
-2. Create a default server secret on the cluster - an example yaml for this can be found in the [examples folder](https://github.com/nginxinc/nginx-ingress-helm-operator/blob/v1.3.1/examples/default-server-secret.yaml)
+2. Create a default server secret on the cluster - an example yaml for this can be found in the [examples folder](https://github.com/nginxinc/nginx-ingress-helm-operator/blob/v1.3.0/examples/default-server-secret.yaml)
 3. (If using OpenShift) Create the scc resource on the cluster by applying the scc.yaml file found in the `resources` folder of this repo:
   ```shell
-  kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.3.1/resources/scc.yaml
+  kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.3.0/resources/scc.yaml
   ```
 4. Deploy a new NGINX Ingress Controller using the [NginxIngress](./config/samples/charts_v1alpha1_nginxingress.yaml) Custom Resource:
     * Use the name of the default server secret created above for `controller.defaultTLS.secret` field (needs to be in the form `namespace/name`)
@@ -63,7 +63,7 @@ See [upgrade docs](./docs/upgrades.md)
 ## NGINX Ingress Operator Releases
 We publish NGINX Ingress Operator releases on GitHub. See our [releases page](https://github.com/nginxinc/nginx-ingress-helm-operator/releases).
 
-The latest stable release is [1.3.1](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.3.1). For production use, we recommend that you choose the latest stable release.
+The latest stable release is [1.3.0](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.3.0). For production use, we recommend that you choose the latest stable release.
 
 ## Development
 

--- a/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
@@ -170,8 +170,8 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring, Networking
     certified: "true"
-    containerImage: nginx/nginx-ingress-operator:1.3.1
-    createdAt: "2023-01-31T11:30:44Z"
+    containerImage: nginx/nginx-ingress-operator:1.3.0
+    createdAt: "2023-01-26T14:28:12Z"
     description: The NGINX Ingress Operator is a Kubernetes/OpenShift component which
       deploys and manages one or more NGINX/NGINX Plus Ingress Controllers
     operatorframework.io/suggested-namespace: nginx-ingress
@@ -184,7 +184,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: nginx-ingress-operator.v1.3.1
+  name: nginx-ingress-operator.v1.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -388,7 +388,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=nginx-ingress-operator
-                image: nginx/nginx-ingress-operator:1.3.1
+                image: nginx/nginx-ingress-operator:1.3.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -479,4 +479,4 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: NGINX Inc
-  version: 1.3.1
+  version: 1.3.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: nginx/nginx-ingress-operator
-  newTag: 1.3.1
+  newTag: 1.3.0

--- a/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
@@ -170,7 +170,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring, Networking
     certified: "true"
-    containerImage: nginx/nginx-ingress-operator:1.3.1
+    containerImage: nginx/nginx-ingress-operator:1.3.0
     createdAt: placeholder
     description: The NGINX Ingress Operator is a Kubernetes/OpenShift component which
       deploys and manages one or more NGINX/NGINX Plus Ingress Controllers
@@ -339,7 +339,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=nginx-ingress-operator
-                image: nginx/nginx-ingress-operator:1.3.1
+                image: nginx/nginx-ingress-operator:1.3.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -445,4 +445,4 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: NGINX Inc
-  version: 1.3.1
+  version: 1.3.0

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -8,17 +8,17 @@ This will deploy the operator in the `nginx-ingress-operator-system` namespace.
     ```
     git clone https://github.com/nginxinc/nginx-ingress-helm-operator/
     cd nginx-ingress-helm-operator/
-    git checkout v1.3.1
+    git checkout v1.3.0
     ```
 
    2. `OpenShift` To deploy the Operator and associated resources to an OpenShift environment, run:
     ```
-    make deploy IMG=nginx/nginx-ingress-operator:1.3.1
+    make deploy IMG=nginx/nginx-ingress-operator:1.3.0
     ```
 
    3. Alternatively, to deploy the Operator and associated resources to all other environments:
     ```
-    make deploy IMG=nginx/nginx-ingress-operator:1.3.1
+    make deploy IMG=nginx/nginx-ingress-operator:1.3.0
     ```
 
 2. Check that the Operator is running:
@@ -33,4 +33,4 @@ This will deploy the operator in the `nginx-ingress-operator-system` namespace.
 
 In order to deploy NGINX Ingress Controller instances into OpenShift environments, a new SCC is required to be created on the cluster which will be used to bind the specific required capabilities to the NGINX Ingress service account(s). To do so, please run the following command (assuming you are logged in with administrator access to the cluster):
 
-`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.3.1/resources/scc.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.3.0/resources/scc.yaml`

--- a/docs/openshift-installation.md
+++ b/docs/openshift-installation.md
@@ -21,6 +21,6 @@ Additional steps:
 
 In order to deploy NGINX Ingress Controller instances into OpenShift environments, a new SCC is required to be created on the cluster which will be used to bind the specific required capabilities to the NGINX Ingress service account(s). To do so, please run the following command (assuming you are logged in with administrator access to the cluster):
 
-`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.3.1/resources/scc.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.3.0/resources/scc.yaml`
 
 You can now deploy the NGINX Ingress Controller instances.


### PR DESCRIPTION
This reverts commit 1204446474ce552c718de778dc6a35d09f5fdb76. 

We don't require an image built without the provenance flag - as it turns out, it did not fix our issue on certification.

Reverting this docs bump and deleting the new tag and images.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork