### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.5.0
+
+An automatically generated list of changes can be found on Github at: [1.5.0 Release](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.5.0)
+
 ### 1.4.2
 
 An automatically generated list of changes can be found on Github at: [1.4.2 Release](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.4.2)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.4.2
+VERSION ?= 1.5.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -180,8 +180,8 @@ bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then v
 	$(OPERATOR_SDK) generate kustomize manifests --interactive=false -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	@printf "%s\n" '' 'LABEL com.redhat.openshift.versions="v4.9"' 'LABEL com.redhat.delivery.operator.bundle=true' 'LABEL com.redhat.delivery.backport=true' >> bundle.Dockerfile
-	@printf "%s\n" '' '  # OpenShift annotations.' '  com.redhat.openshift.versions: v4.9' >> bundle/metadata/annotations.yaml
+	@printf "%s\n" '' 'LABEL com.redhat.openshift.versions="v4.10"' 'LABEL com.redhat.delivery.operator.bundle=true' 'LABEL com.redhat.delivery.backport=true' >> bundle.Dockerfile
+	@printf "%s\n" '' '  # OpenShift annotations.' '  com.redhat.openshift.versions: v4.10' >> bundle/metadata/annotations.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following table shows the relation between the versions of the two projects:
 
 | NGINX Ingress Controller | NGINX Ingress Operator |
 | ------------------------ | ---------------------- |
+| 3.2.x                    | 1.5.0                  |
 | 3.1.x                    | 1.4.2                  |
 | 3.0.x                    | 1.3.1                  |
 | 2.4.x                    | 1.2.1                  |
@@ -67,7 +68,7 @@ See [upgrade docs](./docs/upgrades.md)
 
 We publish NGINX Ingress Operator releases on GitHub. See our [releases page](https://github.com/nginxinc/nginx-ingress-helm-operator/releases).
 
-The latest stable release is [1.4.2](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.4.2). For production use, we recommend that you choose the latest stable release.
+The latest stable release is [1.5.0](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v1.5.0). For production use, we recommend that you choose the latest stable release.
 
 ## Development
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=nginx-ingress-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.30.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
 
@@ -20,6 +20,6 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
 
-LABEL com.redhat.openshift.versions="v4.9"
+LABEL com.redhat.openshift.versions="v4.10"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.delivery.backport=true

--- a/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
@@ -176,8 +176,8 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring, Networking
     certified: "true"
-    containerImage: quay.io/nginx/nginx-ingress-operator:1.4.2
-    createdAt: "2023-06-28T09:38:55Z"
+    containerImage: quay.io/nginx/nginx-ingress-operator:1.5.0
+    createdAt: "2023-06-30T10:10:35Z"
     description: The NGINX Ingress Operator is a Kubernetes/OpenShift component which
       deploys and manages one or more NGINX/NGINX Plus Ingress Controllers
     operatorframework.io/suggested-namespace: nginx-ingress
@@ -190,7 +190,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: nginx-ingress-operator.v1.4.2
+  name: nginx-ingress-operator.v1.5.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -394,7 +394,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=nginx-ingress-operator
-                image: nginx/nginx-ingress-operator:1.4.2
+                image: nginx/nginx-ingress-operator:1.5.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -482,7 +482,7 @@ spec:
   - email: kubernetes@nginx.com
     name: NGINX Inc
   maturity: alpha
-  minKubeVersion: 1.21.0
+  minKubeVersion: 1.22.0
   provider:
     name: NGINX Inc
-  version: 1.4.2
+  version: 1.5.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -15,4 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
   # OpenShift annotations.
-  com.redhat.openshift.versions: v4.9
+  com.redhat.openshift.versions: v4.10

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: nginx/nginx-ingress-operator
-  newTag: 1.4.2
+  newTag: 1.5.0

--- a/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
               "customPorts": [],
               "image": {
                 "repository": "nginx/nginx-ingress",
-                "tag": "3.1.0-ubi",
+                "tag": "3.2.0-ubi",
                 "pullPolicy": "IfNotPresent"
               },
               "lifecycle": {},
@@ -176,7 +176,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring, Networking
     certified: "true"
-    containerImage: quay.io/nginx/nginx-ingress-operator:1.4.2
+    containerImage: quay.io/nginx/nginx-ingress-operator:1.5.0
     createdAt: placeholder
     description: The NGINX Ingress Operator is a Kubernetes/OpenShift component which
       deploys and manages one or more NGINX/NGINX Plus Ingress Controllers
@@ -345,7 +345,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=nginx-ingress-operator
-                image: quay.io/nginx/nginx-ingress-operator:1.4.2
+                image: quay.io/nginx/nginx-ingress-operator:1.5.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -372,8 +372,8 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
-                - --v=10
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9
+                - --v=0
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -448,7 +448,7 @@ spec:
   - email: kubernetes@nginx.com
     name: NGINX Inc
   maturity: alpha
-  minKubeVersion: 1.21.0
+  minKubeVersion: 1.22.0
   provider:
     name: NGINX Inc
-  version: 1.4.2
+  version: 1.5.0

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -7,20 +7,20 @@ This will deploy the operator in the `nginx-ingress-operator-system` namespace.
    1. Clone the `nginx-ingress-operator` repo:
 
    ```
-   git clone https://github.com/nginxinc/nginx-ingress-helm-operator/ --branch v1.4.2
+   git clone https://github.com/nginxinc/nginx-ingress-helm-operator/ --branch v1.5.0
    cd nginx-ingress-helm-operator/
    ```
 
    2. `OpenShift` To deploy the Operator and associated resources to an OpenShift environment, run:
 
    ```
-   make deploy IMG=nginx/nginx-ingress-operator:1.4.2
+   make deploy IMG=nginx/nginx-ingress-operator:1.5.0
    ```
 
    3. Alternatively, to deploy the Operator and associated resources to all other environments:
 
    ```
-   make deploy IMG=nginx/nginx-ingress-operator:1.4.2
+   make deploy IMG=nginx/nginx-ingress-operator:1.5.0
    ```
 
 2. Check that the Operator is running:
@@ -36,10 +36,10 @@ This will deploy the operator in the `nginx-ingress-operator-system` namespace.
 
 In order to deploy NGINX Ingress Controller instances into OpenShift environments, a new SCC is required to be created on the cluster which will be used to bind the specific required capabilities to the NGINX Ingress service account(s). To do so for NIC deployments, please run the following command (assuming you are logged in with administrator access to the cluster):
 
-`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.4.2/resources/scc.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.5.0/resources/scc.yaml`
 
 Alternatively, to create an SCC for NIC daemonsets, please run this command:
 
-`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.4.2/resources/scc-daemonset.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.5.0/resources/scc-daemonset.yaml`
 
 You can now deploy the NGINX Ingress Controller instances.

--- a/docs/openshift-installation.md
+++ b/docs/openshift-installation.md
@@ -21,10 +21,10 @@ Additional steps:
 
 In order to deploy NGINX Ingress Controller instances into OpenShift environments, a new SCC is required to be created on the cluster which will be used to bind the specific required capabilities to the NGINX Ingress service account(s). To do so for NIC deployments, please run the following command (assuming you are logged in with administrator access to the cluster):
 
-`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.4.2/resources/scc.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.5.0/resources/scc.yaml`
 
 Alternatively, to create an SCC for NIC daemonsets, please run this command:
 
-`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.4.2/resources/scc-daemonset.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-ingress-helm-operator/v1.5.0/resources/scc-daemonset.yaml`
 
 You can now deploy the NGINX Ingress Controller instances.

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -8,9 +8,9 @@ Release 1.0.0 includes a backward incompatible change from version 0.5.1 as we h
 1. Upgrade CRDs
 2. Uninstall Go operator -> this will also remove any instances of the NginxIngressController, but not any dependent objects (ingresses, VSs, etc)
 3. Remove the nginx-ingress ingressClass `k delete ingressclass/nginx`
-4. Install new operator 
+4. Install new operator
 5. Deploy common resources (scc, default server secret, ns, etc).
-**Note: Multiple NIC deployments: the RBAC resources should be deployed separately if deploying multiple ICs in same namespace. This is because only one of the ICs in a namespace will be assigned "ownership" of these resources. Similarly, the IngressClass resource needs to be created separately if deploying mutiple NIC instances with a shared IngressClass. See the [README](../README.md) for more information**
+**Note: Multiple NIC deployments: the RBAC resources should be deployed separately if deploying multiple ICs in same namespace. This is because only one of the ICs in a namespace will be assigned "ownership" of these resources. Similarly, the IngressClass resource needs to be created separately if deploying multiple NIC instances with a shared IngressClass. See the [README](../README.md) for more information**
 6. Re-create ingress controllers (note: multi IC rules) using the new Operator. Be sure to use the same configuration as the previous deployments (ingress class name, namespaces etc). They will pick up all deployed dependant resources.
 
 ### 0. Upgrade the existing NIC crds
@@ -19,7 +19,7 @@ Navigate [here](../helm-charts/nginx-ingress/) and run ` kubectl apply -f crds/`
 
 ### 1. Uninstall the existing 0.5.1 operator, the nginx ingress controller CRD, and the ingressClass
 
-Uninstall the operator using the web console - see [the OCP documentation for details](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/pdf/operators/OpenShift_Container_Platform-4.9-Operators-en-US.pdf). 
+Uninstall the operator using the web console - see [the OCP documentation for details](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/pdf/operators/OpenShift_Container_Platform-4.13-Operators-en-US.pdf).
 
 Next uninstall the NIC CRD `nginxingresscontrollers.k8s.nginx.org`. This will remove any instances of the NginxIngressController, but not any dependent objects (ingresses, VSs, etc).
 
@@ -42,7 +42,7 @@ Deploy the operator following the steps outlined in [manual installation doc](./
 ### 2. Cleanup the existing operator
 
 Uninstall the existing operator deployment:
-   
+
 1. Checkout the previous version of the nginx-ingress-operator [0.5.1](https://github.com/nginxinc/nginx-ingress-helm-operator/releases/tag/v0.5.0).
 2. Uninstall the resources by running the following command:
     ```


### PR DESCRIPTION
### Proposed changes
- Updates docs and tags to `1.5.0`
- Bumps min version of OpenShift to v4.10 (v4.9 is deprecated)
- Bumps `ose-kube-rbac-proxy` to `v4.13`
- Fixes `minKubeVersion` that should've been `1.22` already