### PR TITLE
Set SCC's `RunAsUser` as `MustRunAsRange`

### DIFF
--- a/resources/scc-daemonset.yaml
+++ b/resources/scc-daemonset.yaml
@@ -5,8 +5,7 @@ metadata:
   name: nginx-ingress-admin
 allowPrivilegedContainer: false
 runAsUser:
-  type: MustRunAs
-  uid: 101
+  type: MustRunAsRange
 seLinuxContext:
   type: MustRunAs
 fsGroup:

--- a/resources/scc.yaml
+++ b/resources/scc.yaml
@@ -5,8 +5,7 @@ metadata:
   name: nginx-ingress-admin
 allowPrivilegedContainer: false
 runAsUser:
-  type: MustRunAs
-  uid: 101
+  type: MustRunAsRange
 seLinuxContext:
   type: MustRunAs
 fsGroup:


### PR DESCRIPTION
### Proposed changes

Upstream Helm Chart is removing explicit `runAsUser` value from the Deployment and DaemonSet resources. This practically means the UID will be inherited from image's Dockerfile.

Users on vanilla Kubernetes clusters will not observe a change in behavior, unless they have exotic configurations.

However, OpenShift does have additional security measures. It suggests using randomized UIDs/GIDs for workloads. To enable this, the custom Security Context Constraint resources are being updated. The `MustRunAsRange` policy is utilized with pre-allocated values (no explicit range min/max), which effectively allows OpenShift to pick its own ranges.

Relates to nginxinc/kubernetes-ingress#5422.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork