### PR TITLE
allow user to set kube-rbac-proxy image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ OPERATOR_SDK_VERSION ?= v1.34.2
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 
+# kube-rbac-proxy image base
+KRP_IMAGE_BASE ?= quay.io/brancz/kube-rbac-proxy
+
+# kube-rbac-proxy image tag
+KRP_IMAGE_TAG ?= v0.18.0
+
 .PHONY: all
 all: docker-build
 
@@ -179,6 +185,8 @@ endif
 bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests --interactive=false -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd config/manifests/bases && $(KUSTOMIZE) edit set annotation containerImage:$(IMG)
+	cd config/default && $(KUSTOMIZE) edit set image kube-rbac-proxy=$(KRP_IMAGE_BASE):$(KRP_IMAGE_TAG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	@printf "%s\n" '' 'LABEL com.redhat.openshift.versions="v4.12"' 'LABEL com.redhat.delivery.operator.bundle=true' 'LABEL com.redhat.delivery.backport=true' >> bundle.Dockerfile
 	@printf "%s\n" '' '  # OpenShift annotations.' '  com.redhat.openshift.versions: v4.12' >> bundle/metadata/annotations.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,3 +28,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
 - path: manager_auth_proxy_patch.yaml
+images:
+- name: kube-rbac-proxy
+  newName: quay.io/brancz/kube-rbac-proxy
+  newTag: v0.18.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
+        image: kube-rbac-proxy:latest
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manifests/bases/kustomization.yaml
+++ b/config/manifests/bases/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- nginx-ingress-operator.clusterserviceversion.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  containerImage: quay.io/nginx/nginx-ingress-operator:2.3.1

--- a/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring, Networking
     certified: "true"
-    containerImage: quay.io/nginx/nginx-ingress-operator:2.3.1
+    containerImage: nginx-ingress-operator:latest
     createdAt: placeholder
     description: The NGINX Ingress Operator is a Kubernetes/OpenShift component which
       deploys and manages one or more NGINX/NGINX Plus Ingress Controllers
@@ -185,7 +185,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=nginx-ingress-operator
-                image: quay.io/nginx/nginx-ingress-operator:2.3.1
+                image: nginx-ingress-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -288,7 +288,7 @@ spec:
   - email: kubernetes@nginx.com
     name: NGINX Inc
   maturity: alpha
-  minKubeVersion: 1.23.0
+  minKubeVersion: 1.26.0
   provider:
     name: NGINX Inc
-  version: 2.3.1
+  version: 0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/nginx-ingress-operator.clusterserviceversion.yaml
+- bases
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
### Proposed changes
- allow user to set kube-rbac-proxy image & tag via Makefile variables `KRP_IMAGE_BASE` & `KRP_IMAGE_TAG`
- set `containerImage` value when `VERSION` variable changes
- make it clear which values in the templates are placeholders
- bump minimum kubernetes version to 1.26

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork